### PR TITLE
Change a logic of tooling scripts

### DIFF
--- a/fetch-openrc-from-utility.sh
+++ b/fetch-openrc-from-utility.sh
@@ -1,6 +1,15 @@
 #!/bin/bash
-if [[ $(hostname -s) == "controller-01" ]]
-then
+if [[ $(hostname -s) == "controller-01" ]]; then
+
 	# Gets openrc credentials from the utility container on controller-01
 	sudo ssh $(sudo lxc-ls -f | awk '/utility/ {print $1}') cat openrc > /vagrant/openrc
+
+elif [[ $(hostname -s)  == "openstack-client"  ]]; then
+
+	ssh controller-01 "sudo /vagrant/fetch-openrc-from-utility.sh"
+
+else
+
+	vagrant ssh controller-01 -c "sudo /vagrant/fetch-openrc-from-utility.sh"
+
 fi

--- a/resume_environment.sh
+++ b/resume_environment.sh
@@ -5,4 +5,16 @@
 # after a VM resume.
 # This little hack of a script will restart the API service containers for you
 
-vagrant ssh controller-01 -c "sudo lxc-ls -f | egrep -v \"NAME|galera|rabbit|utility|rsyslog|repo\" | awk '{print \$1}' | while read C; do echo \"Rebooting \${C}\"; sudo lxc-stop -r -n \${C}; done"
+if [[ $(hostname -s) == "controller-01" ]]; then
+
+	sudo lxc-ls -f | egrep -v "NAME|galera|rabbit|utility|rsyslog|repo" | awk '{print $1}' | while read C; do echo "Rebooting ${C}"; sudo lxc-stop -r -n ${C}; done
+
+elif [[ $(hostname -s) == "openstack-client" ]]; then
+
+	ssh controller-01 "sudo lxc-ls -f | egrep -v \"NAME|galera|rabbit|utility|rsyslog|repo\" | awk '{print \$1}' | while read C; do echo \"Rebooting \${C}\"; sudo lxc-stop -r -n \${C}; done"
+
+else
+
+	vagrant ssh controller-01 -c "sudo lxc-ls -f | egrep -v \"NAME|galera|rabbit|utility|rsyslog|repo\" | awk '{print \$1}' | while read C; do echo \"Rebooting \${C}\"; sudo lxc-stop -r -n \${C}; done"
+
+fi


### PR DESCRIPTION
Updated scripts can be run from 
- the controller-01 machine
- the openstack-client machine
- a Vagrant-based host