### PR TITLE
Updated "state" for module "apt" to "latest"

### DIFF
--- a/roles/prereqs/tasks/main.yml
+++ b/roles/prereqs/tasks/main.yml
@@ -7,7 +7,7 @@
 - name: Install Pre-Req Packages
   apt:
     name: "{{ item }}"
-    state: installed
+    state: latest
     cache_valid_time: 3600
     install_recommends: yes
     force: yes


### PR DESCRIPTION
Previous state was "installed" which is, according to error messages and the Ansible documentation, not a valid state. 
Changed to "latest" which ensures that the latest version of the package is installed.