### PR TITLE
Updated syntax for running "networking.sh"

### DIFF
--- a/roles/networking/tasks/main.yml
+++ b/roles/networking/tasks/main.yml
@@ -6,4 +6,5 @@
   template: src=openstack.j2 dest=/etc/network/interfaces.d/openstack.cfg owner=root group=root mode=0644
 
 - name: Edit Networking
-  shell: /vagrant/networking.sh
+  shell: 
+    cmd: bash /vagrant/networking.sh


### PR DESCRIPTION
Previous configuration led to error "/bin/sh: 1: /vagrant/networking.sh: not found". 
Fixes #38 

